### PR TITLE
Return response data in verror info

### DIFF
--- a/__tests__/axios-verror.test.js
+++ b/__tests__/axios-verror.test.js
@@ -47,6 +47,9 @@ describe('enhance', () => {
         method: 'POST',
         status: 400,
         url: 'http://nock/',
+        data: {
+          message: 'invalid request',
+        },
       }
     });
   });
@@ -76,6 +79,9 @@ describe('enhance', () => {
         method: 'GET',
         status: 400,
         url: 'http://nock/',
+        data: {
+          message: 'invalid request',
+        },
       }
     });
   });
@@ -105,6 +111,9 @@ describe('enhance', () => {
         method: 'GET',
         status: 400,
         url: 'http://nock/',
+        data: {
+          message: 'invalid request',
+        },
       }
     });
   });
@@ -135,8 +144,40 @@ describe('enhance', () => {
         method: 'GET',
         status: 400,
         url: 'http://nock/foo',
+        data: {
+          message: 'invalid request',
+        },
       }
     });
   });
 
+  test('no message body', async () => {
+    nock('http://nock')
+      .post('/')
+      .reply(400, { reason: 'invalid request' });
+    let caught = null;
+    try {
+      await axios.request({
+        url: 'http://nock/',
+        method: 'POST',
+        data: { param: 'foo' },
+      }).catch(AxiosVError.enhance);
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught.message).toEqual(
+      '[400] POST http://nock/: Request failed with status code 400'
+    );
+    expect(VError.info(caught)).toEqual({
+      axios: {
+        res: caught.jse_cause.response,
+        method: 'POST',
+        status: 400,
+        url: 'http://nock/',
+        data: {
+          reason: 'invalid request',
+        },
+      }
+    });
+  });
 });

--- a/axios-verror.js
+++ b/axios-verror.js
@@ -53,6 +53,7 @@ function enhanceError(err) {
   const method = (config.method || config.type || 'GET').toUpperCase();
   const url = formatUrl(config);
   const status = res?.status;
+  const data = res?.data;
   const message = this.extractMessage(res);
   const errorMessage = this.formatSummary({
     url,
@@ -70,6 +71,7 @@ function enhanceError(err) {
         url,
         status,
         message,
+        data
       },
     },
   }, errorMessage);


### PR DESCRIPTION
It's not uncommon that APIs return error messages under many different keys.
This change will by default, return the entire body of a response message in the info of a VError.

