### PR TITLE
⬆️ Update to Node 22

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '14.x'
+          node-version: '22.x'
       - run: yarn install --frozen-lockfile
       - run: yarn test --ci
   lint:
@@ -22,6 +22,6 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '14.x'
+          node-version: '22.x'
       - run: yarn install --frozen-lockfile
       - run: yarn lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           registry-url: 'https://registry.npmjs.org'
       - run: yarn install --frozen-lockfile
       - run: scripts/version-tag-validate.js ${{ github.ref }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.2.3 - 2025-06-02
+### Changed
+- upgraded node engine requirement
+
 ## 1.2.2 - 2024-10-28
 ### Changed
 - refresh lockfile to remove references to @babel/traverse<7.23.2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centrapay/axios-verror",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Enhance Axios request errors using VError",
   "main": "axios-verror.js",
   "scripts": {


### PR DESCRIPTION
The maintenance mode for node 18 ends in April 2025. Node 22 to is the
current long term support version.

https://nodejs.org/en/about/previous-releases

Test plan:
- Confirm service starts locally and local tests run without errors
- Confirm Github workflow jobs succeed and there are no Node 22 related
  warnings in the logs