### PR TITLE
chore: add CODEOWNERS for package.json and yarn.lock file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+yarn.lock @centrapay/ptsd
+package.json @centrapay/ptsd


### PR DESCRIPTION
## Context

We want dependabot to auto assign @centrapay/ptsd as reviewer for PR that it creates.

## Change

This PR adds @centrapay/ptsd as CODEOWNER for `package.json` and `yarn.lock` files.